### PR TITLE
Add enrolled attribute for user when registering in responder svc

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -31,6 +31,7 @@ export class HomeComponent implements OnInit {
               responder.phoneNumber = profile['attributes'].phoneNumber[0];
               responder.boatCapacity = profile['attributes'].boatCapacity[0];
               responder.medicalKit = profile['attributes'].medical[0];
+              responder.enrolled = false;
               responder.person = true;
               responder.available = false;
 


### PR DESCRIPTION
Currently the responder service will fail if the user does not
provide an enrolled value. To avoid this we'll set enrolled to
false by default.