### PR TITLE
Stop mobile sidebar showing when it shouldn't

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -99,7 +99,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private handleMissions(missions: Mission[]): void {
     missions.forEach((mission: Mission) => {
       const status = mission.status;
-
       switch (status) {
         case 'CREATED': {
           this.assigned++;


### PR DESCRIPTION
Currently we toggle the sidebar when checking whether the screen
is small enough to be a mobile. This causes the sidebar to show
and hide in intervals.

We shouldn't toggle, instead we should be explicit to close the
sidebar.